### PR TITLE
Accept absolute and ~/ paths for --file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ in seconds rather than minutes.
 5. Continue the discussion by adding replies to comment threads in the browser
 6. Repeat steps 4-5 until the document matches your intent
 
+### File paths
+
+The `--file` argument accepts:
+
+- a path relative to the current working directory (the original behaviour):
+  `/cr-review PLAN.md`
+- an absolute path — the parent directory is treated as the project:
+  `/cr-review /Users/me/.claude/plans/PLAN.md`
+- a `~/`-prefixed path (Claude Code's slash commands quote `$ARGUMENTS`, so the
+  shell does not expand `~` for you):
+  `/cr-review ~/.claude/plans/PLAN.md`
+
+This is useful when the document lives outside your project — for example,
+plans Claude Code writes to `~/.claude/plans/`.
+
 ## Requirements
 
 - Linux or macOS

--- a/main.go
+++ b/main.go
@@ -30,7 +30,12 @@ import (
 // user did pass --project explicitly we leave it alone; otherwise an absolute
 // --file overrides it.
 func resolveFileArg(projectDir, filePath *string, projectDirDefaultedToCwd bool) {
+	// Slash-command substitution of "$ARGUMENTS" can preserve leading or
+	// trailing whitespace that the user (or the model) typed; trim first so
+	// the prefix checks below don't all silently miss.
+	*filePath = strings.TrimSpace(*filePath)
 	*filePath = strings.TrimPrefix(*filePath, "@")
+	*filePath = strings.TrimSpace(*filePath)
 
 	if strings.HasPrefix(*filePath, "~/") {
 		if home, err := os.UserHomeDir(); err == nil {

--- a/main.go
+++ b/main.go
@@ -7,11 +7,42 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
+
+// resolveFileArg normalizes a --file value supplied to review/address/resolve.
+// It handles three Claude-Code-flavoured inputs that the existing code did not:
+//
+//  1. a leading "@" (paste artefact from the Claude Code UI),
+//  2. a leading "~/" (tilde expansion is suppressed when slash-commands quote
+//     "$ARGUMENTS"),
+//  3. an absolute path (e.g. "/Users/me/.claude/plans/foo.md") — in that case
+//     the parent directory becomes the project directory and the basename the
+//     file path, so the existing filepath.Join(projectDir, filePath) on the
+//     server side resolves to the file the user actually meant.
+//
+// projectDirDefaultedToCwd indicates whether the caller has already populated
+// *projectDir from os.Getwd() (i.e. the user did not pass --project). When the
+// user did pass --project explicitly we leave it alone; otherwise an absolute
+// --file overrides it.
+func resolveFileArg(projectDir, filePath *string, projectDirDefaultedToCwd bool) {
+	*filePath = strings.TrimPrefix(*filePath, "@")
+
+	if strings.HasPrefix(*filePath, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			*filePath = filepath.Join(home, (*filePath)[2:])
+		}
+	}
+
+	if filepath.IsAbs(*filePath) && projectDirDefaultedToCwd {
+		*projectDir = filepath.Dir(*filePath)
+		*filePath = filepath.Base(*filePath)
+	}
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -205,7 +236,8 @@ func runReview() {
 	}
 
 	// Resolve project directory (default to current directory)
-	if *projectDir == "" || *projectDir == "." {
+	projectDirDefaulted := *projectDir == "" || *projectDir == "."
+	if projectDirDefaulted {
 		cwd, err := os.Getwd()
 		if err != nil {
 			log.Fatalf("Failed to get current directory: %v", err)
@@ -218,8 +250,7 @@ func runReview() {
 		os.Exit(1)
 	}
 
-	// Remove @ prefix if present
-	*filePath = strings.TrimPrefix(*filePath, "@")
+	resolveFileArg(projectDir, filePath, projectDirDefaulted)
 
 	// Step 1: Start daemon if not running
 	if !isServerRunning() {
@@ -264,7 +295,8 @@ func runAddress() {
 	}
 
 	// Resolve project directory (default to current directory)
-	if *projectDir == "" || *projectDir == "." {
+	projectDirDefaulted := *projectDir == "" || *projectDir == "."
+	if projectDirDefaulted {
 		cwd, err := os.Getwd()
 		if err != nil {
 			log.Fatalf("Failed to get current directory: %v", err)
@@ -276,8 +308,7 @@ func runAddress() {
 		os.Exit(1)
 	}
 
-	// Remove @ prefix if present
-	*filePath = strings.TrimPrefix(*filePath, "@")
+	resolveFileArg(projectDir, filePath, projectDirDefaulted)
 
 	// Initialize database
 	if err := initDB(); err != nil {
@@ -489,7 +520,8 @@ func runResolve() {
 
 	// Handle file mode (original behavior)
 	// Resolve project directory (default to current directory)
-	if *projectDir == "" || *projectDir == "." {
+	projectDirDefaulted := *projectDir == "" || *projectDir == "."
+	if projectDirDefaulted {
 		cwd, err := os.Getwd()
 		if err != nil {
 			log.Fatalf("Failed to get current directory: %v", err)
@@ -501,8 +533,7 @@ func runResolve() {
 		os.Exit(1)
 	}
 
-	// Remove @ prefix if present
-	*filePath = strings.TrimPrefix(*filePath, "@")
+	resolveFileArg(projectDir, filePath, projectDirDefaulted)
 
 	// Debug: show what we're searching for
 	log.Printf("Searching for comments: project_directory=%q, file_path=%q", *projectDir, *filePath)

--- a/main_test.go
+++ b/main_test.go
@@ -68,6 +68,38 @@ func TestResolveFileArg(t *testing.T) {
 			wantProjectDir:           filepath.Join(home, ".claude/plans"),
 			wantFilePath:             "foo.md",
 		},
+		{
+			name:                     "leading space before ~/",
+			inProjectDir:             "/cwd",
+			inFilePath:               " ~/.claude/plans/foo.md",
+			projectDirDefaultedToCwd: true,
+			wantProjectDir:           filepath.Join(home, ".claude/plans"),
+			wantFilePath:             "foo.md",
+		},
+		{
+			name:                     "leading space before absolute path",
+			inProjectDir:             "/cwd",
+			inFilePath:               " /Users/me/.claude/plans/foo.md",
+			projectDirDefaultedToCwd: true,
+			wantProjectDir:           "/Users/me/.claude/plans",
+			wantFilePath:             "foo.md",
+		},
+		{
+			name:                     "trailing whitespace stripped",
+			inProjectDir:             "/cwd",
+			inFilePath:               "sub/plan.md  \t\n",
+			projectDirDefaultedToCwd: true,
+			wantProjectDir:           "/cwd",
+			wantFilePath:             "sub/plan.md",
+		},
+		{
+			name:                     "space between @ and ~/",
+			inProjectDir:             "/cwd",
+			inFilePath:               "@ ~/.claude/plans/foo.md",
+			projectDirDefaultedToCwd: true,
+			wantProjectDir:           filepath.Join(home, ".claude/plans"),
+			wantFilePath:             "foo.md",
+		},
 	}
 
 	for _, tc := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveFileArg(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir: %v", err)
+	}
+
+	tests := []struct {
+		name                     string
+		inProjectDir             string
+		inFilePath               string
+		projectDirDefaultedToCwd bool
+		wantProjectDir           string
+		wantFilePath             string
+	}{
+		{
+			name:                     "strips @ prefix",
+			inProjectDir:             "/repo",
+			inFilePath:               "@docs/plan.md",
+			projectDirDefaultedToCwd: false,
+			wantProjectDir:           "/repo",
+			wantFilePath:             "docs/plan.md",
+		},
+		{
+			name:                     "expands ~/ when projectDir is default",
+			inProjectDir:             "/cwd",
+			inFilePath:               "~/.claude/plans/foo.md",
+			projectDirDefaultedToCwd: true,
+			wantProjectDir:           filepath.Join(home, ".claude/plans"),
+			wantFilePath:             "foo.md",
+		},
+		{
+			name:                     "absolute file splits into dir+base when projectDir is default",
+			inProjectDir:             "/cwd",
+			inFilePath:               "/Users/me/.claude/plans/foo.md",
+			projectDirDefaultedToCwd: true,
+			wantProjectDir:           "/Users/me/.claude/plans",
+			wantFilePath:             "foo.md",
+		},
+		{
+			name:                     "absolute file with explicit projectDir is left relative-style alone",
+			inProjectDir:             "/explicit",
+			inFilePath:               "/Users/me/file.md",
+			projectDirDefaultedToCwd: false,
+			wantProjectDir:           "/explicit",
+			wantFilePath:             "/Users/me/file.md",
+		},
+		{
+			name:                     "relative path is unchanged",
+			inProjectDir:             "/cwd",
+			inFilePath:               "sub/plan.md",
+			projectDirDefaultedToCwd: true,
+			wantProjectDir:           "/cwd",
+			wantFilePath:             "sub/plan.md",
+		},
+		{
+			name:                     "combined @ and ~/",
+			inProjectDir:             "/cwd",
+			inFilePath:               "@~/.claude/plans/foo.md",
+			projectDirDefaultedToCwd: true,
+			wantProjectDir:           filepath.Join(home, ".claude/plans"),
+			wantFilePath:             "foo.md",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			projectDir := tc.inProjectDir
+			filePath := tc.inFilePath
+			resolveFileArg(&projectDir, &filePath, tc.projectDirDefaultedToCwd)
+			if projectDir != tc.wantProjectDir {
+				t.Errorf("projectDir = %q, want %q", projectDir, tc.wantProjectDir)
+			}
+			if filePath != tc.wantFilePath {
+				t.Errorf("filePath = %q, want %q", filePath, tc.wantFilePath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Make `claude-review review/address/resolve --file` accept absolute paths
and `~/`-prefixed paths, not just paths relative to `--project`.

## Motivation

The shipped `/cr-review` and `/cr-address` slash commands invoke
`claude-review` like this:

```
claude-review review --file "$ARGUMENTS"
```

`$ARGUMENTS` is quoted, so the shell does **not** expand a leading `~`.
And the CLI itself does no path normalisation beyond stripping an
optional `@`. Two practical consequences:

- `/cr-review ~/.claude/plans/PLAN.md` ends up looking for a literal
  file named `~` in the CWD.
- Claude Code writes its plans to `~/.claude/plans/`, which is almost
  never the CWD the user is invoking the slash command from — so
  reviewing one of those plans requires `cd`ing first.

Reported in a Claude Code session as: *"Claude Code by default
generates plans in `~/.claude/plans`, but `/cr-review` and `/cr-address`
only look in the CWD."*

## Change

Factor the existing `@`-prefix strip into a small helper,
`resolveFileArg`, that additionally:

- expands a leading `~/` (`os.UserHomeDir`), and
- when `--file` is absolute **and** the user did not supply `--project`,
  splits the path into dir + basename so the existing
  `filepath.Join(projectDir, filePath)` on the server still resolves
  correctly.

The helper is called from `runReview`, `runAddress`, and `runResolve`
(the three subcommands that take `--file`).

## Behaviour matrix

| `--project`    | `--file`                              | resulting project    | resulting file |
| -------------- | ------------------------------------- | -------------------- | -------------- |
| (default CWD)  | `PLAN.md`                             | CWD                  | `PLAN.md`      |
| (default CWD)  | `@PLAN.md`                            | CWD                  | `PLAN.md`      |
| (default CWD)  | `~/.claude/plans/PLAN.md`             | `~/.claude/plans`    | `PLAN.md`      |
| (default CWD)  | `/Users/me/.claude/plans/PLAN.md`     | `/Users/me/.claude/plans` | `PLAN.md` |
| `/explicit`    | `/Users/me/PLAN.md`                   | `/explicit` (unchanged) | `/Users/me/PLAN.md` |

An explicit `--project` is left alone, so this is opt-in: existing
relative-path invocations behave byte-identically.

## Test plan

- [x] New table-driven `TestResolveFileArg` in `main_test.go` covering
      `@` strip, `~/` expansion, absolute split, explicit-project
      override, plain relative, and `@~/...` combined.
- [x] `go test ./...` — all existing e2e tests still pass (~28s).
- [x] `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)